### PR TITLE
Minor fix

### DIFF
--- a/script.js
+++ b/script.js
@@ -83,10 +83,9 @@ var requiredAlternative = {
 		elm.addEventListener('invalid', function(invalid){
 			var form = (this.form === null) ? orphans : this.form;
 			if(form.ElementList[this.name].length > 1){
-				var first = form.ElementList[this.name][0];
-				var nativeValueMissing = ((this.type == 'checkbox' && !this.checked) || (this.type != 'checkbox' && !this.value) && this.required);
-				if(nativeValueMissing != this.validity.valueMissing){
+				if((this.type == 'checkbox' && !this.checked) || (this.type != 'checkbox' && !this.value) && !this.validity.valueMissing){
 					// if a value is defined or a checkbox checked in the group, do nothing
+					// only useful for polyfills not relying upon "required" attribute
 					invalid.preventDefault();
 				}
 			}


### PR DESCRIPTION
Canceling an invalid event is part of an older commit. It was meant to be useful for blocking the "invalid" event triggered by a required, empty control.
This has already been solved by altering the "required" IDL attribute, but I saved this feature in case ReqAlt is used together with a validation polyfill which does not rely upon a (custom) "required" property. Now it is fixed accordingly.
